### PR TITLE
raise ConnectionError instead RuntimeErrror

### DIFF
--- a/hdfs3/compatibility.py
+++ b/hdfs3/compatibility.py
@@ -1,12 +1,17 @@
 import sys
 
 if sys.version_info < (3,):
+
+    class ConnectionError(OSError):
+        """Connection to HDFS failed."""
+
     FileNotFoundError = IOError
     PermissionError = IOError
     from urlparse import urlparse
     unicode = unicode
     bytes = str
 else:
+    ConnectionError = ConnectionError
     PermissionError = PermissionError
     FileNotFoundError = FileNotFoundError
     from urllib.parse import urlparse

--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 import ctypes
 import logging
 import os
-import subprocess
 import sys
 import re
 import warnings
@@ -13,8 +12,8 @@ from .lib import _lib
 
 PY3 = sys.version_info.major > 2
 
-from .compatibility import FileNotFoundError, PermissionError, urlparse
-from .utils import seek_delimiter, read_block
+from .compatibility import FileNotFoundError,  urlparse, ConnectionError
+from .utils import read_block
 
 
 logger = logging.getLogger(__name__)
@@ -186,7 +185,7 @@ class HDFileSystem(object):
             #                                             ensure_bytes(self.user))
         else:
             msg = ensure_string(_lib.hdfsGetLastError())
-            raise RuntimeError('Connection Failed: {}'.format(msg))
+            raise ConnectionError('Connection Failed: {}'.format(msg))
 
     def disconnect(self):
         """ Disconnect from name node """

--- a/hdfs3/tests/test_hdfs3.py
+++ b/hdfs3/tests/test_hdfs3.py
@@ -11,7 +11,7 @@ import pytest
 
 from hdfs3 import HDFileSystem, lib
 from hdfs3.core import conf_to_dict, ensure_bytes, ensure_string
-from hdfs3.compatibility import bytes, unicode
+from hdfs3.compatibility import bytes, unicode, ConnectionError
 from hdfs3.utils import tmpfile
 
 
@@ -46,7 +46,7 @@ def test_simple(hdfs):
         assert out == data
 
 def test_connection_error():
-    with pytest.raises(RuntimeError) as ctx:
+    with pytest.raises(ConnectionError) as ctx:
         hdfs = HDFileSystem(host='localhost', port=9999, connect=False)
         hdfs.connect()
     # error message is long and with java exceptions, so here we just check


### PR DESCRIPTION
Raising RuntimeError if case connection error a bit misleading, here simple patch for that.
Please review.