### PR TITLE
Write in chunks

### DIFF
--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -702,9 +702,13 @@ class HDFile(object):
         if not _lib.hdfsFileIsOpenForWrite(self._handle):
             msg = ensure_string(_lib.hdfsGetLastError())
             raise IOError('File not write mode: {}'.format(msg))
-        if not _lib.hdfsWrite(self._fs, self._handle, data, len(data)) == len(data):
-            msg = ensure_string(_lib.hdfsGetLastError())
-            raise IOError('Write failed on file %s' % (self.path, msg))
+        write_block = 64 * 2**20
+        for offset in range(0, len(data), write_block):
+            d = data[offset:offset + write_block]
+            if not _lib.hdfsWrite(self._fs, self._handle, d, len(d)) == len(d):
+                msg = ensure_string(_lib.hdfsGetLastError())
+                raise IOError('Write failed on file %s' % (self.path, msg))
+        return len(data)
 
     def flush(self):
         """ Send buffer to the data-node; actual write to disc may happen later """

--- a/hdfs3/tests/test_hdfs3.py
+++ b/hdfs3/tests/test_hdfs3.py
@@ -159,6 +159,15 @@ def test_write_blocksize(hdfs):
         hdfs.open(a, 'rb', block_size=123)
 
 
+def test_write_vbig(hdfs):
+    with hdfs.open(a, 'wb') as f:
+        f.write(b' ' * 2**31)
+    assert hdfs.info(a)['size'] == 2**31
+    with hdfs.open(a, 'wb') as f:
+        f.write(b' ' * (2**31 + 1))
+    assert hdfs.info(a)['size'] == 2**31 + 1
+
+
 def test_replication(hdfs):
     path = '/tmp/test/afile'
     hdfs.open(path, 'wb', replication=0).close()

--- a/hdfs3/tests/test_hdfs3.py
+++ b/hdfs3/tests/test_hdfs3.py
@@ -159,6 +159,7 @@ def test_write_blocksize(hdfs):
         hdfs.open(a, 'rb', block_size=123)
 
 
+@pytest.mark.slow
 def test_write_vbig(hdfs):
     with hdfs.open(a, 'wb') as f:
         f.write(b' ' * 2**31)


### PR DESCRIPTION
Even if the data passed to write is huge, write in chunks.

Think the error came from casting the length of the data to c in
an int that couldn't fit that size.

Closes #70 