### PR TITLE
PR: Include lineterminator in readline

### DIFF
--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -566,6 +566,7 @@ class HDFile(object):
         self._handle = None
         self.mode = mode
         self.block_size = block_size
+        self.lines = deque([])
         self._set_handle()
 
     def _set_handle(self):
@@ -621,8 +622,7 @@ class HDFile(object):
         Line iteration uses this method internally.
         """
         lineterminator = ensure_bytes(lineterminator)
-        lines = getattr(self, 'lines', deque([]))
-        if len(lines) < 2:
+        if len(self.lines) < 2:
             buffers = []
             while True:
                 out = self.read(chunksize)
@@ -630,10 +630,11 @@ class HDFile(object):
                 if lineterminator in out:
                     break
                 if not out:
-                    remains = list(lines)
+                    remains = list(self.lines)
                     self.lines = deque([])
                     return b''.join(remains + buffers)
-            self.lines = deque(b''.join(list(lines) + buffers).split(lineterminator))
+            self.lines = deque(b''.join(list(self.lines) +
+                                        buffers).split(lineterminator))
         return self.lines.popleft() + lineterminator
 
     def _genline(self):

--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -8,6 +8,7 @@ import os
 import sys
 import re
 import warnings
+from collections import deque
 from .lib import _lib
 
 PY3 = sys.version_info.major > 2
@@ -561,7 +562,7 @@ class HDFile(object):
         self.replication = replication
         self.buff = buff
         self._fs = fs._handle
-        self.buffer = b''
+        self.buffers = []
         self._handle = None
         self.mode = mode
         self.block_size = block_size
@@ -620,24 +621,27 @@ class HDFile(object):
         Line iteration uses this method internally.
         """
         lineterminator = ensure_bytes(lineterminator)
-        lines = getattr(self, 'lines', [])
-        if len(lines) < 1:
-            buff = self.read(chunksize)
-            if len(buff) == 0:   #EOF
-                remains = self.buffer
-                if remains:
-                    self.buffer = b''
-                    return remains
-                raise EOFError
-            buff = (self.buffer + buff)
-            self.lines = buff.split(lineterminator)
-        return self.lines.pop(0)
+        lines = getattr(self, 'lines', deque([]))
+        if len(lines) < 2:
+            buffers = []
+            while True:
+                out = self.read(chunksize)
+                buffers.append(out)
+                if lineterminator in out:
+                    break
+                if not out:
+                    remains = list(lines)
+                    self.lines = deque([])
+                    return b''.join(remains + buffers)
+            self.lines = deque(b''.join(list(lines) + buffers).split(lineterminator))
+        return self.lines.popleft() + lineterminator
 
     def _genline(self):
         while True:
-            try:
-                yield self.readline()
-            except EOFError:
+            out = self.readline()
+            if out:
+                yield out
+            else:
                 raise StopIteration
 
     def __iter__(self):

--- a/hdfs3/tests/test_hdfs3.py
+++ b/hdfs3/tests/test_hdfs3.py
@@ -437,7 +437,7 @@ def test_readline(hdfs, lineterminator):
         assert f.readline(lineterminator=lineterminator) == b'123'+lineterminator
         assert f.readline(lineterminator=lineterminator) == b'456'+lineterminator
         assert f.readline(lineterminator=lineterminator) == b'789'
-        assert f.readline(lineterminator=lineterminator) == ''
+        assert f.readline(lineterminator=lineterminator) == b''
 
 
 def read_write(hdfs, i):

--- a/hdfs3/tests/test_hdfs3.py
+++ b/hdfs3/tests/test_hdfs3.py
@@ -434,11 +434,10 @@ def test_readline(hdfs, lineterminator):
         f.write(lineterminator.join([b'123', b'456', b'789']))
 
     with hdfs.open(a) as f:
-        assert f.readline(lineterminator=lineterminator) == b'123'
-        assert f.readline(lineterminator=lineterminator) == b'456'
+        assert f.readline(lineterminator=lineterminator) == b'123'+lineterminator
+        assert f.readline(lineterminator=lineterminator) == b'456'+lineterminator
         assert f.readline(lineterminator=lineterminator) == b'789'
-        with pytest.raises(EOFError):
-            f.readline()
+        assert f.readline(lineterminator=lineterminator) == ''
 
 
 def read_write(hdfs, i):
@@ -549,11 +548,21 @@ def test_readlines(hdfs):
 
     with hdfs.open(a, 'rb') as f:
         lines = f.readlines()
-        assert lines == [b'123', b'456']
+        assert lines == [b'123\n', b'456']
+
+    with hdfs.open(a, 'rb') as f:
+        assert list(f) == lines
 
     with hdfs.open(a, 'wb') as f:
         with pytest.raises(IOError):
             f.read()
+
+    bigdata = [b'fe', b'fi', b'fo'] * 32000
+    with hdfs.open(a, 'wb') as f:
+        f.write(b'\n'.join(bigdata))
+    with hdfs.open(a, 'rb') as f:
+        lines = list(f)
+    assert all(l in [b'fe\n', b'fi\n', b'fo', b'fo\n'] for l in lines)
 
 
 def test_put(hdfs):


### PR DESCRIPTION
(also refactored how the lines were read; readline at end of file
now returns empty bytestring)

Fixes #77 