### PR TITLE
Byteslike

### DIFF
--- a/hdfs3/mapping.py
+++ b/hdfs3/mapping.py
@@ -64,8 +64,6 @@ class HDFSMap(MutableMapping):
 
     def __setitem__(self, key, value):
         key = self._key_to_str(key)
-        if not isinstance(value, bytes):
-            raise TypeError("Value must be of type bytes")
         with self.hdfs.open(key, 'wb') as f:
             f.write(value)
 

--- a/hdfs3/tests/test_hdfs3.py
+++ b/hdfs3/tests/test_hdfs3.py
@@ -754,3 +754,15 @@ def test_closed(hdfs):
     assert not f.closed()
     f.close()
     assert f.closed()
+
+
+def test_array(hdfs):
+    from array import array
+    data = array('B', [65] * 1000)
+
+    with hdfs.open(a, 'wb') as f:
+        f.write(data)
+
+    with hdfs.open(a, 'rb') as f:
+        out = f.read()
+        assert out == b'A' * 1000

--- a/hdfs3/tests/test_mapping.py
+++ b/hdfs3/tests/test_mapping.py
@@ -60,3 +60,19 @@ def test_pickle(hdfs):
     d2 = pickle.loads(pickle.dumps(d))
 
     assert d2['x'] == b'1'
+
+
+def test_array(hdfs):
+    from array import array
+    d = HDFSMap(hdfs, root)
+    d['x'] = array('B', [65] * 1000)
+
+    assert d['x'] == b'A' * 1000
+
+
+def test_bytearray(hdfs):
+    from array import array
+    d = HDFSMap(hdfs, root)
+    d['x'] = bytearray(b'123')
+
+    assert d['x'] == b'123'


### PR DESCRIPTION
Allow `array.array` and `bytesarray` to be written to files.

Cf. https://github.com/dask/s3fs/pull/39
