### PR TITLE
PR: Make HDFile pickleable

### DIFF
--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -654,6 +654,19 @@ class HDFile(object):
             else:
                 raise StopIteration
 
+    def __getstate__(self):
+        d = self.__dict__.copy()
+        del d['_handle']
+        del d['_fs']
+        logger.debug("Serialize with state: %s", d)
+        return d
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.fs.connect()
+        self._fs = self.fs._handle
+        self._set_handle()
+
     def __iter__(self):
         """ Enables `for line in file:` usage """
         return self._genline()

--- a/hdfs3/tests/test_hdfs3.py
+++ b/hdfs3/tests/test_hdfs3.py
@@ -5,6 +5,7 @@ import multiprocessing
 import os
 import tempfile
 import sys
+import pickle
 from random import randint
 from threading import Thread
 
@@ -778,3 +779,12 @@ def test_array(hdfs):
     with hdfs.open(a, 'rb') as f:
         out = f.read()
         assert out == b'A' * 1000
+
+
+def test_pickle(hdfs):
+    with hdfs.open(a, 'wb') as f:
+        f2 = pickle.loads(pickle.dumps(f))
+        assert f2._handle != f._handle
+        f2.write(b'data')
+        f2.close()
+    assert hdfs.cat(a) == b'data'


### PR DESCRIPTION
Essentially re-opens file on deserialization. This means multiple
processes may now have the same file open - should make sure only
one is writing.
