### PR TITLE
Do not set port if port is None, required for HA mode

### DIFF
--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -157,7 +157,7 @@ class HDFileSystem(object):
             raise RunteimError(m)
 
         self.ticket_cache = ticket_cache
-        self.pars = pars
+        self.pars = pars or {}
         self._handle = None
         if connect:
             self.connect()

--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -182,7 +182,7 @@ class HDFileSystem(object):
             return
 
         o = _lib.hdfsNewBuilder()
-        if port is not None:
+        if self.port is not None:
             _lib.hdfsBuilderSetNameNodePort(o, self.port)
         _lib.hdfsBuilderSetNameNode(o, ensure_bytes(self.host))
         if self.user:

--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -152,9 +152,9 @@ class HDFileSystem(object):
         self.port = port
         self.user = user
 
-        if not (ticket_cache and token):
+        if ticket_cache and token:
             m = "It is not possible to use ticket_cache and token in same time"
-            raise RunteimError(m)
+            raise RuntimeError(m)
 
         self.ticket_cache = ticket_cache
         self.pars = pars or {}

--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -157,6 +157,7 @@ class HDFileSystem(object):
             raise RuntimeError(m)
 
         self.ticket_cache = ticket_cache
+        self.token = token
         self.pars = pars or {}
         self._handle = None
         if connect:

--- a/hdfs3/tests/test_hdfs3.py
+++ b/hdfs3/tests/test_hdfs3.py
@@ -12,6 +12,7 @@ import pytest
 
 from hdfs3 import HDFileSystem, lib
 from hdfs3.core import conf_to_dict, ensure_bytes, ensure_string
+from hdfs3.core import DEFAULT_HOST, DEFAULT_PORT
 from hdfs3.compatibility import bytes, unicode, ConnectionError
 from hdfs3.utils import tmpfile
 
@@ -27,6 +28,7 @@ def hdfs():
 
     if hdfs.exists('/tmp/test'):
         hdfs.rm('/tmp/test')
+    hdfs.disconnect()
 
 
 a = '/tmp/test/a'
@@ -45,6 +47,24 @@ def test_simple(hdfs):
         out = f.read(len(data))
         assert len(data) == len(out)
         assert out == data
+
+
+def test_default_port_and_host():
+    hdfs = HDFileSystem(connect=False)
+    assert hdfs.host == DEFAULT_HOST
+    assert hdfs.port == DEFAULT_PORT
+
+
+def test_token_and_ticket_cache_in_same_time()
+    ticket_cache = "/tmp/krb5cc_0"
+    token = 'abc"
+
+    with pytest.raises(RuntimeError) as ctx:
+        HDFileSystem(connect=False, ticket_cache=ticket_cache, token=token)
+
+    msg = "It is not possible to use ticket_cache and token in same time"
+    assert msg in str(ctx.value)
+
 
 def test_connection_error():
     with pytest.raises(ConnectionError) as ctx:

--- a/hdfs3/tests/test_hdfs3.py
+++ b/hdfs3/tests/test_hdfs3.py
@@ -55,9 +55,9 @@ def test_default_port_and_host():
     assert hdfs.port == DEFAULT_PORT
 
 
-def test_token_and_ticket_cache_in_same_time()
+def test_token_and_ticket_cache_in_same_time():
     ticket_cache = "/tmp/krb5cc_0"
-    token = 'abc"
+    token = "abc"
 
     with pytest.raises(RuntimeError) as ctx:
         HDFileSystem(connect=False, ticket_cache=ticket_cache, token=token)


### PR DESCRIPTION
`hdfs3` should have ability not to set port for HA mode, so `libhdfs3` can do right thing and use multiple namenodes. Here simple fix for this

Related issue: https://github.com/dask/hdfs3/issues/62