### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ hdfs3 is a lightweight Python wrapper for libhdfs3_, a native C/C++ library to i
 View the documentation_ for hdfs3.
 
 .. _libhdfs3: https://github.com/PivotalRD/libhdfs3
-.. _documentation: http://hdfs3.readthedocs.io/en/latest/
+.. _documentation: https://hdfs3.readthedocs.io/en/latest/
 
 .. |Build Status| image:: https://travis-ci.org/dask/hdfs3.svg?branch=master
     :target: https://travis-ci.org/dask/hdfs3

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -70,6 +70,6 @@ Related Work
 
 .. _`Hadoop File System`: https://en.wikipedia.org/wiki/Apache_Hadoop
 .. _libhdfs3: http://pivotalrd.github.io/libhdfs3/
-.. _snakebite: http://snakebite.readthedocs.io/en/latest/
+.. _snakebite: https://snakebite.readthedocs.io/en/latest/
 .. _Dask: http://dask.pydata.org/en/latest/
-.. _Dask.distributed: http://distributed.readthedocs.org/en/latest/
+.. _Dask.distributed: https://distributed.readthedocs.io/en/latest/

--- a/hdfs3/lib.py
+++ b/hdfs3/lib.py
@@ -15,7 +15,7 @@ try:
 except OSError:
     raise ImportError("Can not find the shared library: libhdfs3.so\n"
             "See installation instructions at "
-            "http://hdfs3.readthedocs.io/en/latest/install.html")
+            "https://hdfs3.readthedocs.io/en/latest/install.html")
 
 
 tSize = ct.c_int32


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.