### PR TITLE
Pin to Python 3.5 in CI

### DIFF
--- a/continuous_integration/Dockerfile
+++ b/continuous_integration/Dockerfile
@@ -11,7 +11,7 @@ ENV PATH /opt/conda/bin:$PATH
 ENV LIBHDFS3_CONF /etc/hadoop/conf/hdfs-site.xml
 RUN conda install -y -q ipython pytest
 RUN conda install -y -q libhdfs3 -c conda-forge
-RUN conda create -y -n py3 python=3
+RUN conda create -y -n py3 python=3.5
 RUN conda install -y -n py3 ipython pytest
 RUN conda install -y -n py3 libhdfs3 -c conda-forge
 


### PR DESCRIPTION
Pins `python=3.5` in Dockerfile used in CI. Otherwise, `python=3` will use the new Python 3.6 packages, which will result in `UnsatisfiableError`s.