### PR TITLE
Simplify conffile interpretation

### DIFF
--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -50,24 +50,13 @@ def conf_to_dict(fname):
         val = val_match.search(line)
         if val:
             val = val.groups()[0]
-            try:
-                val = int(val)
-            except ValueError:
-                try:
-                    val = float(val)
-                except ValueError:
-                    pass
-            if val == 'false':
-                val = False
-            if val == 'true':
-                val = True
             conf[key] = val
     return conf
 
 
 conf = hdfs_conf()
 DEFAULT_HOST = conf.get('host', 'localhost')
-DEFAULT_PORT = conf.get('port', 8020)
+DEFAULT_PORT = int(conf.get('port', 8020))
 
 
 def ensure_bytes(s):

--- a/hdfs3/tests/test_hdfs3.py
+++ b/hdfs3/tests/test_hdfs3.py
@@ -424,12 +424,12 @@ def conffile():
 
 
 def test_conf(conffile):
-    should = {'dfs.block.size': 134217728,
-             'dfs.datanode.hdfs-blocks-metadata.enabled': True,
+    should = {'dfs.block.size': '134217728',
+             'dfs.datanode.hdfs-blocks-metadata.enabled': 'true',
              'dfs.namenode.name.dir': '/mnt/data/dfs/nn',
-             'dfs.permissions': False,
+             'dfs.permissions': 'false',
              'dfs.permissions.superusergroup': 'hadoop',
-             'dfs.replication': 3}
+             'dfs.replication': '3'}
     assert conf_to_dict(conffile) == should
 
 


### PR DESCRIPTION
Conf values are passed as strings/bytes anyway, no point in
converting.

Fixes #109 