### PR TITLE
Add test function that emphasize an issue when mixing read and readline calls + partial solution

### DIFF
--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -14,7 +14,7 @@ from .lib import _lib
 PY3 = sys.version_info.major > 2
 
 from .compatibility import FileNotFoundError, urlparse, ConnectionError
-from .utils import read_block, seek_delimiter
+from .utils import read_block
 
 
 logger = logging.getLogger(__name__)
@@ -607,36 +607,50 @@ class HDFile(object):
                           (self.path, self.mode, msg))
         self._handle = out
 
+    def _fetch_hdfs(self, length=None):
+        """Fill internal read buffer."""
+        bufsize = min(2**16, length)
+        p = ctypes.create_string_buffer(bufsize)
+        ret = _lib.hdfsRead(self._fs, self._handle,
+                            p, ctypes.c_int32(bufsize))
+        if ret == 0:
+            return ret
+        elif ret >= 0:
+            self.buffers.append(p.raw[:ret])
+            return ret
+        else:
+            raise IOError('Read file %s Failed:' % self.path, -ret)
+
     def read(self, length=None):
         """ Read bytes from open file """
         if not _lib.hdfsFileIsOpenForRead(self._handle):
             raise IOError('File not read mode')
-        buffers = []
 
         if length is None:
-            out = 1
-            while out:
-                out = self.read(2**16)
-                buffers.append(out)
+            while self._fetch_hdfs(2**16):
+                pass
+            result = b''.join(self.buffers)
+            self.buffers = []
         else:
+            read_buf = []
             while length:
-                bufsize = min(2**16, length)
-                p = ctypes.create_string_buffer(bufsize)
-                ret = _lib.hdfsRead(self._fs, self._handle, p, ctypes.c_int32(bufsize))
-                if ret == 0:
-                    break
-                if ret > 0:
-                    if ret < bufsize:
-                        buffers.append(p.raw[:ret])
-                    elif ret == bufsize:
-                        buffers.append(p.raw)
-                    length -= ret
+                self._fetch_hdfs(2**16)
+                if len(self.buffers):
+                    out = self.buffers.pop(0)
+                    if len(out) > length:
+                        read_buf.append(out[:length])
+                        self.buffers.insert(0, out[length:])
+                        length = 0
+                    else:
+                        read_buf.append(out)
+                        length -= len(out)
                 else:
-                    raise IOError('Read file %s Failed:' % self.path, -ret)
+                    break
+            result = b''.join(read_buf)
 
-        return b''.join(buffers)
+        return result
 
-    def readline(self, chunksize=2**8, lineterminator='\n'):
+    def readline(self, chunksize=2**16, lineterminator='\n'):
         """ Return a line using buffered reading.
 
         Reads and caches chunksize bytes of data, and caches lines
@@ -649,11 +663,25 @@ class HDFile(object):
         Line iteration uses this method internally.
         """
         lineterminator = ensure_bytes(lineterminator)
-        start = self.tell()
-        seek_delimiter(self, lineterminator, chunksize, allow_zero=False)
-        end = self.tell()
-        self.seek(start)
-        return self.read(end - start)
+        line_buffer = []
+        while True:
+            ret = 1
+            if len(self.buffers):
+                out = self.buffers.pop(0)
+                terminator_position = out.find(lineterminator)
+                if terminator_position == -1:
+                    line_buffer.append(out)
+                else:
+                    endline, remaining = out.split(lineterminator, 1)
+                    line_buffer.append(endline)
+                    line_buffer.append(lineterminator)
+                    self.buffers.insert(0, remaining)
+                    break
+            else:
+                ret = self._fetch_hdfs(chunksize)
+            if ret == 0:
+                break
+        return b''.join(line_buffer)
 
     def _genline(self):
         while True:

--- a/hdfs3/tests/test_hdfs3.py
+++ b/hdfs3/tests/test_hdfs3.py
@@ -858,3 +858,21 @@ def test_array(hdfs):
     with hdfs.open(a, 'rb') as f:
         out = f.read()
         assert out == b'A' * 1000
+
+
+def test_read_after_readline(hdfs):
+    mem_f = io.BytesIO()
+
+    data = b'aaaaaaaaaaaa\nbbbbbbbbbbbbb\ncccccccccc\nddddddddddddd'
+    mem_f.write(data)
+    mem_f.seek(0)
+
+    with hdfs.open(a, 'wb') as hdfs_f:
+        hdfs_f.write(data)
+
+    with hdfs.open(a, 'rb') as hdfs_f:
+        assert hdfs_f.read(3) == mem_f.read(3)
+        assert hdfs_f.readline() == mem_f.readline()
+        assert hdfs_f.read(5) == mem_f.read(5)
+        assert hdfs_f.readline() == mem_f.readline()
+        assert hdfs_f.read() == mem_f.read()


### PR DESCRIPTION
This PR is related to #107 and #108.

When pickle reloads binary type objects (not text), it mixes calls to read and readline. This test basically reproduces this behaviour.

The  problem seems to come from the internal read/readline buffers of each function that are not shared although readline depends on read.

I came up with a solution that fixes the particular case below but not my general use case with persiting numpy arrays with joblib dump/load function.

Here is a basic snippet that reproduce the issue:

```python
 import array
 import hdfs3
 import pickle
 import io
 from pickle import _Unpickler
 
 a = array.array('d', [1, 2, 3])
 
 hdfs = hdfs3.HDFileSystem(host='localhost', port=8020, user='user')
 
 print("############## DUMP to FS")
 with open('/tmp/debug_array.pkl', 'wb') as f:
     pickle.dump(a, f)
 
 print("############## DUMP to HDFS")
 with hdfs.open('/user/debug_array.pkl', 'wb') as f:
     pickle.dump(a, f)
 
 print("############## LOAD from FS")
 with open('/tmp/debug_array.pkl', 'rb') as f:
     print(_Unpickler(f).load())
 
 print("############## LOAD from HDFS")
 with hdfs.open('/user/debug_array.pkl', 'rb') as f:
     print(_Unpickler(f).load())

```

You can also try with numpy arrays instead of array.array.

Maybe @ogrisel could help also (as we worked together on that today).