### PR TITLE
Readline and reads can now be interwoven

### DIFF
--- a/hdfs3/tests/test_utils.py
+++ b/hdfs3/tests/test_utils.py
@@ -36,17 +36,17 @@ def test_read_block():
     f = BytesIO(data)
 
     assert read_block(f, 1, 2) == b'23'
-    assert read_block(f, 0, 1, delimiter=b'\n') == b'123'
-    assert read_block(f, 0, 2, delimiter=b'\n') == b'123'
-    assert read_block(f, 0, 3, delimiter=b'\n') == b'123'
-    assert read_block(f, 0, 5, delimiter=b'\n') == b'123\n456'
+    assert read_block(f, 0, 1, delimiter=b'\n') == b'123\n'
+    assert read_block(f, 0, 2, delimiter=b'\n') == b'123\n'
+    assert read_block(f, 0, 3, delimiter=b'\n') == b'123\n'
+    assert read_block(f, 0, 5, delimiter=b'\n') == b'123\n456\n'
     assert read_block(f, 0, 8, delimiter=b'\n') == b'123\n456\n789'
     assert read_block(f, 0, 100, delimiter=b'\n') == b'123\n456\n789'
     assert read_block(f, 1, 1, delimiter=b'\n') == b''
-    assert read_block(f, 1, 5, delimiter=b'\n') == b'456'
+    assert read_block(f, 1, 5, delimiter=b'\n') == b'456\n'
     assert read_block(f, 1, 8, delimiter=b'\n') == b'456\n789'
 
     for ols in [[(0, 3), (3, 3), (6, 3), (9, 2)],
                 [(0, 4), (4, 4), (8, 4)]]:
         out = [read_block(f, o, l, b'\n') for o, l in ols]
-        assert delimiter.join(filter(None, out)) == data
+        assert b''.join(filter(None, out)) == data

--- a/hdfs3/utils.py
+++ b/hdfs3/utils.py
@@ -5,7 +5,7 @@ import shutil
 import tempfile
 
 
-def seek_delimiter(file, delimiter, blocksize):
+def seek_delimiter(file, delimiter, blocksize, allow_zero=True):
     """ Seek current file to next byte after a delimiter bytestring
 
     This seeks the file to the next byte following the delimiter.  It does
@@ -20,7 +20,7 @@ def seek_delimiter(file, delimiter, blocksize):
         Number of bytes to read from the file at once.
     """
 
-    if file.tell() == 0:
+    if file.tell() == 0 and allow_zero:
         return
 
     last = b''
@@ -85,9 +85,6 @@ def read_block(f, offset, length, delimiter=None):
 
         offset = start
         length = end - start
-
-        if length and not eof:
-            length -= len(delimiter)
 
     f.seek(offset)
     bytes = f.read(length)


### PR DESCRIPTION
Also:
- readline now includes terminator

...but readline is much slower now, relying only on libhdfs3's internal buffer.
Could contemplate doing full internal buffering like in s3fs.

Possible replacement for #116 

Fixes #88 