### PR TITLE
Update default location for conf files

### DIFF
--- a/hdfs3/core.py
+++ b/hdfs3/core.py
@@ -24,7 +24,7 @@ def hdfs_conf(conf_dir=None):
     """ Load HDFS config from default locations. """
     if conf_dir == None:
         confd = os.environ.get('HADOOP_CONF_DIR', os.environ.get('HADOOP_INSTALL',
-                           '') + '/hadoop/conf')
+                           '/etc') + '/hadoop/conf')
     else:
         confd = conf_dir
     files = 'core-site.xml', 'hdfs-site.xml'


### PR DESCRIPTION
In most[^1] Hadoop installation, the Hadoop configuration is
located at `/etc/hadoop/conf/`.

I think it makes sense to make it easier.

[^1] Good people, expert people are saying this.
