### PR TITLE
Show error on .so load failure; fix conf strip

### DIFF
--- a/hdfs3/conf.py
+++ b/hdfs3/conf.py
@@ -34,7 +34,9 @@ def hdfs_conf(confd, more_files=None):
         return
     if 'fs.defaultFS' in c and c['fs.defaultFS'].startswith('hdfs'):
         # default FS in 'core'
-        text = c['fs.defaultFS'].strip('hdfs://')
+        text = c['fs.defaultFS']
+        if text.startswith('hdfs://'):
+            text = text[7:]
         host = text.split(':', 1)[0]
         port = text.split(':', 1)[1:]
         if host:

--- a/hdfs3/lib.py
+++ b/hdfs3/lib.py
@@ -13,8 +13,10 @@ _lib = None
 for name in ['libhdfs3.so', 'libhdfs3.dylib']:
     try:
         _lib = ct.cdll.LoadLibrary(name)
+        break
     except OSError as e:
-        if not e.args or "image not found" not in str(e.args[0]):
+        if not e.args or ("image not found" not in str(e.args[0])
+                          and "No such file" not in str(e)):
             raise
 if _lib is None:
     raise ImportError("Can not find the shared library: libhdfs3.so\n"

--- a/hdfs3/lib.py
+++ b/hdfs3/lib.py
@@ -13,11 +13,9 @@ _lib = None
 for name in ['libhdfs3.so', 'libhdfs3.dylib']:
     try:
         _lib = ct.cdll.LoadLibrary(name)
-    except OSError:
-        pass
-        # import os
-        # env = os.path.dirname(os.path.dirname(sys.executable))
-        # _lib = ct.cdll.LoadLibrary(os.path.join(env, 'lib', 'libhdfs3.so'))
+    except OSError as e:
+        if not e.args or "image not found" not in str(e.args[0]):
+            raise
 if _lib is None:
     raise ImportError("Can not find the shared library: libhdfs3.so\n"
                       "See installation instructions at "


### PR DESCRIPTION
It .so fails to load for any other reason apart from "not found",
reraise the error.

@jcrist : sneaked the strip() fix into here. Didn't apply the broader conf changes yet.