### PR TITLE
Walk matches `os.walk` behavior

### DIFF
--- a/hdfs3/mapping.py
+++ b/hdfs3/mapping.py
@@ -1,4 +1,4 @@
-
+import posixpath
 from collections import MutableMapping
 
 
@@ -68,8 +68,13 @@ class HDFSMap(MutableMapping):
             f.write(value)
 
     def keys(self):
-        l = len(self.root) + 1
-        return (fn[l:] for fn in self.hdfs.walk(self.root) if len(fn) > l)
+        for dirname, _, files in self.hdfs.walk(self.root):
+            if dirname == self.root:
+                base = ''
+            else:
+                base = posixpath.relpath(dirname, self.root)
+            for fn in files:
+                yield posixpath.join(base, fn)
 
     def __iter__(self):
         return self.keys()

--- a/hdfs3/tests/test_mapping.py
+++ b/hdfs3/tests/test_mapping.py
@@ -23,7 +23,7 @@ def test_with_data(hdfs):
     assert mw['x'] == b'123'
     assert bool(mw)
 
-    assert set(hdfs.walk(root)) == {root+'/x', root}
+    assert hdfs.ls(root) == [root + '/x']
     mw['x'] = b'000'
     assert mw['x'] == b'000'
 


### PR DESCRIPTION
Currently this interface doesn't match the standard `os.walk` interface, which returns an iterator of `dirname, dirs, files`. This fixes that, and cleans up a few other methods that were using `walk`.

Note that I'm not sure if we should deprecate the old interface (how many people rely on this functionality?), and if so how should we go about doing the deprecation.